### PR TITLE
[FEAT] 統一將「coding」的簡中翻譯「編碼」改為更加語意化的「撰寫程式碼」

### DIFF
--- a/review/developer/small-cls.md
+++ b/review/developer/small-cls.md
@@ -10,7 +10,7 @@
 - **在被拒絕時減少浪費的工作。** 如果您編寫了一個龐大的 CL，然後您的審查人員說整個方向錯了，那麼您就浪費了很多工作。
 - **更容易合併。** 在大的 CL 上工作需要很長時間，因此當您進行合併操作時會遇到很多衝突，而且您還需要經常進行合併。
 - **更方便設計。** 改進小的變更的設計和程式碼更容易，而詳細修改大變更的所有細節要更困難。
-- **在審查時的阻礙更少。** 傳送自包含的整個變更的部分可以讓您在等待當前 CL 審查時繼續編碼。
+- **在審查時的阻礙更少。** 傳送自包含的整個變更的部分可以讓您在等待當前 CL 審查時繼續撰寫程式碼。
 - **還原更簡單。** 大的 CL 將更有可能觸及在初始 CL 提交和復原 CL 之間被更新的檔案，從而使復原變得更加複雜 (中間的 CL 可能也需要復原)。
 
 Small, simple CLs are:
@@ -102,7 +102,7 @@ immediately.
 
 ## 分割 CLs (Splitting CLs) {#splitting}
 
-當要處理具有潛在相依關係的多個 CL 工作時，通常在開始編碼之前，先從高層次考慮如何分割和組織這些 CL 會很有幫助。
+當要處理具有潛在相依關係的多個 CL 工作時，通常在開始撰寫程式碼之前，先從高層次考慮如何分割和組織這些 CL 會很有幫助。
 
 When starting work that will have multiple CLs with potential dependencies among
 each other, it's often useful to think about how to split and organize those CLs

--- a/review/reviewer/speed.md
+++ b/review/reviewer/speed.md
@@ -53,7 +53,7 @@ review (if needed) within a single day.
 
 ## 速度 vs. 中斷 (Speed vs. Interruption) {#中斷}
 
-有一個情況，個人速度比團隊速度更重要。**如果你正在進行一個專注的任務，例如編寫程式碼，不要中斷自己來進行程式碼審查。**研究表明，開發人員在被打斷後重新進入順暢的開發流程可能需要很長時間。因此，打斷自己編碼實際上比讓另一個開發人員等待一段時間進行程式碼審查*更*貴重。
+有一個情況，個人速度比團隊速度更重要。**如果你正在進行一個專注的任務，例如編寫程式碼，不要中斷自己來進行程式碼審查。**研究表明，開發人員在被打斷後重新進入順暢的開發流程可能需要很長時間。因此，打斷自己撰寫程式碼實際上比讓另一個開發人員等待一段時間進行程式碼審查*更*貴重。
 
 There is one time where the consideration of personal velocity trumps team
 velocity. **If you are in the middle of a focused task, such as writing code,
@@ -64,7 +64,7 @@ after being interrupted. So interrupting yourself while coding is actually
 *more* expensive to the team than making another developer wait a bit for a code
 review.
 
-相反的，等待你工作的斷點再回應請求進行審查。斷點可能是你目前的編碼任務完成後、午餐後、從會議回來後或是從休息室回來後等等。
+相反的，等待你工作的斷點再回應請求進行審查。斷點可能是你目前的撰寫程式碼任務完成後、午餐後、從會議回來後或是從休息室回來後等等。
 
 Instead, wait for a break point in your work before you respond to a request for
 review. This could be when your current coding task is completed, after lunch,


### PR DESCRIPTION
您好，目前文件中有關「coding」的英文翻譯使用「編碼」一詞。然而，這個詞彙在台灣地區有著不一樣的語意。

因此，為了提高文件中用詞的可讀性和一致性，本人這邊發了一個「更加語意化的 coding 文字用詞」的 PR。這樣能夠讓台灣地區的讀者較不容易誤解 coding 這個詞的意思。

如果您對此 PR 有任何建議的話，歡迎您隨時通知本人。

感謝您的審查和協助。