### PR TITLE
[FEAT] 修正部分簡中用詞

### DIFF
--- a/review/developer/handling-comments.md
+++ b/review/developer/handling-comments.md
@@ -8,7 +8,7 @@ about handling reviewer comments.
 
 ## 不要把它當成個人攻擊 (Don't Take it Personally) {#personal}
 
-審查的目標是維護我們程式庫和產品的品質。當審查者對您的程式碼提出評論時，請把這視為他們試圖幫助您、程式庫和 Google，而不是對您或您的能力的個人攻擊。
+審查的目標是維護我們程式碼庫和產品的品質。當審查者對您的程式碼提出評論時，請把這視為他們試圖幫助您、程式碼庫和 Google，而不是對您或您的能力的個人攻擊。
 
 The goal of review is to maintain the quality of our codebase and our products.
 When a reviewer provides a critique of your code, think of it as their attempt
@@ -105,7 +105,7 @@ ways to collaborate: ask for clarifications, discuss pros/cons, and provide
 explanations of why your method of doing things is better for the codebase,
 users, and/or Google.
 
-有時候，你可能會對使用者、原始碼庫(codebase)或該項 CL 的情況有更多瞭解，而評審者可能尚未瞭解的內容。如適當地[修正程式碼](#code)，並透過討論與分享更多背景資訊來與評審者互動。通常，你可以基於技術事實與評審者達成共識。
+有時候，你可能會對使用者、程式碼庫(codebase)或該項 CL 的情況有更多瞭解，而評審者可能尚未瞭解的內容。如適當地[修正程式碼](#code)，並透過討論與分享更多背景資訊來與評審者互動。通常，你可以基於技術事實與評審者達成共識。
 
 Sometimes, you might know something about the users, codebase, or CL that the
 reviewer doesn't know. [Fix the code](#code) where appropriate, and engage your

--- a/review/emergencies.md
+++ b/review/emergencies.md
@@ -8,7 +8,7 @@ possible.
 
 ## 什麼是緊急情況？ (What Is An Emergency?) {#what}
 
-緊急程式庫 (CL) 將是一個「小」更改，允許主要的發佈繼續進行而不會復原，修復影響使用者產生重大影響的錯誤，在生產環境中處理迫切的法律問題，關閉主要的安全漏洞等。
+緊急 CL 將是一個「小」更改，允許主要的發佈繼續進行而不會復原，修復影響使用者產生重大影響的錯誤，在生產環境中處理迫切的法律問題，關閉主要的安全漏洞等。
 
 An emergency CL would be a **small** change that: allows a major launch to
 continue instead of rolling back, fixes a bug significantly affecting users in

--- a/review/reviewer/comments.md
+++ b/review/reviewer/comments.md
@@ -31,7 +31,7 @@ saying something that might otherwise be upsetting or contentious. For example:
 Bad: "Why did **you** use threads here when there's obviously no benefit to be
 gained from concurrency?"
 
-好的："這裡的併發模型正在增加系統的複雜度，但我沒有看到任何實際的效能收益。由於沒有效能收益，最好讓此代碼成為單線程，而不是使用多執行緒。"
+好的："這裡的併發模型正在增加系統的複雜度，但我沒有看到任何實際的效能收益。由於沒有效能收益，最好讓此代碼成為單執行緒，而不是使用多執行緒。"
 
 Good: "The concurrency model here is adding complexity to the system without any
 actual performance benefit that I can see. Because there's no performance

--- a/review/reviewer/comments.md
+++ b/review/reviewer/comments.md
@@ -116,7 +116,7 @@ comments are merely intended to be informational or optional.
 
 ## 接受解釋 (Accepting Explanations) {#explanations}
 
-如果您要求開發人員解釋您不瞭解的一段程式碼，通常應該導致他們更清晰地**重寫程式碼**。偶爾，在程式碼中新增注釋也是一種適當的反應，只要不僅僅是解釋過於複雜的代碼。
+如果您要求開發人員解釋您不瞭解的一段程式碼，通常應該導致他們更清晰地**重寫程式碼**。偶爾，在程式碼中新增註解也是一種適當的反應，只要不僅僅是解釋過於複雜的代碼。
 
 If you ask a developer to explain a piece of code that you don't understand,
 that should usually result in them **rewriting the code more clearly**.


### PR DESCRIPTION
您好，目前文件中 Azure OpenAI Service 翻譯時所使用的詞彙與文法有些與台灣地區的習慣不一致，而這樣的不一致性容易造成台灣讀者的困擾。

為了提高文件的可讀性，本人這邊發了一個「校正部分詞彙與文法」的 PR，以避免台灣地區的讀者因為閱讀習慣的不一致而感到困擾。

如果您對此 PR 有任何建議的話，歡迎您隨時通知本人。

感謝您的審查和協助。