### PR TITLE
[FEAT] 統一「reviewer」翻譯

### DIFF
--- a/review/developer/cl-descriptions.md
+++ b/review/developer/cl-descriptions.md
@@ -57,7 +57,7 @@ the best approach. If there are any shortcomings to the approach, they should be
 mentioned. If relevant, include background information such as bug numbers,
 benchmark results, and links to design documents.
 
-如果您包含外部資源的連結，要考慮到因存取限制或保留政策，這些連結可能對未來讀者不可見。在可能的情況下，請提供足夠的上下文讓審閱者和未來的讀者理解程式碼。
+如果您包含外部資源的連結，要考慮到因存取限制或保留政策，這些連結可能對未來讀者不可見。在可能的情況下，請提供足夠的上下文讓審查者和未來的讀者理解程式碼。
 
 If you include links to external resources consider that they may not be visible
 to future readers due to access restrictions or retention policies. Where
@@ -176,7 +176,7 @@ Example:
 > instead of Python2, and significantly simplifies some automated build file
 > refactoring tools being worked on currently.
 
-第一句話描述實際正在做什麼。其餘的描述解釋了為什麼要進行更改，並為審查人員提供了很多背景。
+第一句話描述實際正在做什麼。其餘的描述解釋了為什麼要進行更改，並為審查者提供了很多背景。
 
 The first sentence describes what's actually being done. The rest of the
 description explains *why* the change is being made and gives the reviewer a lot

--- a/review/developer/handling-comments.md
+++ b/review/developer/handling-comments.md
@@ -1,6 +1,6 @@
-# 如何處理審稿人意見 (How to handle reviewer comments)
+# 如何處理審查者意見 (How to handle reviewer comments)
 
-當您發送一個供審查的 CL 時，您的審查人員可能會對您的 CL 發表多條評論。下面是有關處理審查人員評論的一些有用資訊。
+當您發送一個供審查的 CL 時，您的審查者可能會對您的 CL 發表多條評論。下面是有關處理審查者評論的一些有用資訊。
 
 When you've sent a CL out for review, it's likely that your reviewer will
 respond with several comments on your CL. Here are some useful things to know
@@ -15,7 +15,7 @@ When a reviewer provides a critique of your code, think of it as their attempt
 to help you, the codebase, and Google, rather than as a personal attack on you
 or your abilities.
 
-有時審查人員會感到沮喪，並在他們的評論中表達這種沮喪。雖然這對於審查人員來說並不是一種好的實踐，但作為開發人員，您應該為此做好準備。問問自己："評審人員試圖要傳達給我哪些建設性的內容？"，然後像他們實際說的那樣去操作。
+有時審查者會感到沮喪，並在他們的評論中表達這種沮喪。雖然這對於審查者來說並不是一種好的實踐，但作為開發人員，您應該為此做好準備。問問自己："審查者試圖要傳達給我哪些建設性的內容？"，然後像他們實際說的那樣去操作。
 
 Sometimes reviewers feel frustrated and they express that frustration in their
 comments. This isn't a good practice for reviewers, but as a developer you
@@ -31,7 +31,7 @@ are too angry or annoyed to respond kindly, then walk away from your computer
 for a while, or work on something else until you feel calm enough to reply
 politely.
 
-通常情況下，如果評審無法以有建設性且有禮貌的方式提供反饋，請親自向他們解釋。如果您無法當面或透過視訊通話與他們交談，請透過私人電子郵件與他們聯繫。以友好的方式告訴他們您不喜歡什麼，以及您希望他們做不同的事情。如果他們對這個私人討論也以非建設性的方式回應，或是沒有達到預期的效果，那就根據情況提升給您的經理。
+通常情況下，如果審查者無法以有建設性且有禮貌的方式提供反饋，請親自向他們解釋。如果您無法當面或透過視訊通話與他們交談，請透過私人電子郵件與他們聯繫。以友好的方式告訴他們您不喜歡什麼，以及您希望他們做不同的事情。如果他們對這個私人討論也以非建設性的方式回應，或是沒有達到預期的效果，那就根據情況提升給您的經理。
 
 In general, if a reviewer isn't providing feedback in a way that's constructive
 and polite, explain this to them in person. If you can't talk to them in person
@@ -44,7 +44,7 @@ appropriate.
 
 ## 修正程式碼 (Fix the Code) {#code}
 
-如果審查人員表示無法理解您的程式碼，您應該首先澄清程式碼本身。如果程式碼無法澄清，則新增一個代碼註解來解釋代碼存在的原因。如果評論似乎毫無意義，那麼您的回應應該是在程式碼審查工具中進行解釋。
+如果審查者表示無法理解您的程式碼，您應該首先澄清程式碼本身。如果程式碼無法澄清，則新增一個代碼註解來解釋代碼存在的原因。如果評論似乎毫無意義，那麼您的回應應該是在程式碼審查工具中進行解釋。
 
 If a reviewer says that they don't understand something in your code, your first
 response should be to clarify the code itself. If the code can't be clarified,
@@ -52,7 +52,7 @@ add a code comment that explains why the code is there. If a comment seems
 pointless, only then should your response be an explanation in the code review
 tool.
 
-如果審查人員沒有理解你的一些程式碼，未來閱讀這些程式碼的人可能也不會理解。在程式碼審查工具中撰寫回應並不會幫助未來閱讀程式碼的人，但是澄清你的程式碼或新增程式碼註解則能對他們有所幫助。
+如果審查者沒有理解你的一些程式碼，未來閱讀這些程式碼的人可能也不會理解。在程式碼審查工具中撰寫回應並不會幫助未來閱讀程式碼的人，但是澄清你的程式碼或新增程式碼註解則能對他們有所幫助。
 
 If a reviewer didn't understand some piece of your code, it's likely other
 future readers of the code won't understand either. Writing a response in the
@@ -68,14 +68,14 @@ send one out for review, feel like it's done, and be pretty sure that no further
 work is needed. It can be frustrating to receive comments asking for changes,
 especially if you don't agree with them.
 
-在這種情況下，請花些時間退一步並考慮評審者是否提供了有助於程式基礎和 Google 的有價值反饋。你應該始終首先問自己的問題是："我瞭解評審者的要求嗎？"
+在這種情況下，請花些時間退一步並考慮審查者是否提供了有助於程式基礎和 Google 的有價值反饋。你應該始終首先問自己的問題是："我瞭解審查者的要求嗎？"
 
 At times like this, take a moment to step back and consider if the reviewer is
 providing valuable feedback that will help the codebase and Google. Your first
 question to yourself should always be, "Do I understand what the reviewer is
 asking for?"
 
-如果你無法回答那個問題，請詢問審閱者以取得澄清。
+如果你無法回答那個問題，請詢問審查者以取得澄清。
 
 If you can't answer that question, ask the reviewer for clarification.
 
@@ -96,7 +96,7 @@ My understanding is that using Y would be worse because of [these reasons]. Are
 you suggesting that Y better serves the original tradeoffs, that we should weigh
 the tradeoffs differently, or something else?"
 
-請記住，**禮貌和尊重**應始終是首要考慮。如果您不同意審查人員，請尋找合作方式：請求澄清，討論優缺點，並解釋為什麼您執行任務的方法對於程式碼庫、使用者和/或 Google 更優。
+請記住，**禮貌和尊重**應始終是首要考慮。如果您不同意審查者，請尋找合作方式：請求澄清，討論優缺點，並解釋為什麼您執行任務的方法對於程式碼庫、使用者和/或 Google 更優。
 
 Remember,
 **[courtesy and respect](https://chromium.googlesource.com/chromium/src/+/master/docs/cr_respect.md)
@@ -105,7 +105,7 @@ ways to collaborate: ask for clarifications, discuss pros/cons, and provide
 explanations of why your method of doing things is better for the codebase,
 users, and/or Google.
 
-有時候，你可能會對使用者、原始碼庫(codebase)或該項 CL 的情況有更多瞭解，而評審者可能尚未瞭解的內容。如適當地[修正程式碼](#code)，並透過討論與分享更多背景資訊來與評審者互動。通常，你可以基於技術事實與評審者達成共識。
+有時候，你可能會對使用者、程式碼庫或該項 CL 的情況有更多瞭解，而審查者可能尚未瞭解的內容。如適當地[修正程式碼](#code)，並透過討論與分享更多背景資訊來與審查者互動。通常，你可以基於技術事實與審查者達成共識。
 
 Sometimes, you might know something about the users, codebase, or CL that the
 reviewer doesn't know. [Fix the code](#code) where appropriate, and engage your
@@ -114,7 +114,7 @@ to some consensus between yourself and the reviewer based on technical facts.
 
 ## 解決衝突 (Resolving Conflicts) {#conflicts}
 
-解決衝突的第一步應該是嘗試與審查人達成共識。如果無法達成共識，請參閱[程式碼審查標準](../reviewer/standard.md)，其中提供了在這種情況下應遵循的原則。
+解決衝突的第一步應該是嘗試與審查者達成共識。如果無法達成共識，請參閱[程式碼審查標準](../reviewer/standard.md)，其中提供了在這種情況下應遵循的原則。
 
 Your first step in resolving conflicts should always be to try to come to
 consensus with your reviewer. If you can't achieve consensus, see

--- a/review/developer/index.md
+++ b/review/developer/index.md
@@ -6,6 +6,6 @@ The pages in this section contain best practices for developers going through co
 
 - [撰寫良好的 CL 描述 (Writing Good CL Descriptions)](cl-descriptions.md)
 - [小的變更清單 (Small CLs)](small-cls.md)
-- [如何處理審稿人意見 (How to Handle Reviewer Comments)](handling-comments.md)
+- [如何處理審查者意見 (How to Handle Reviewer Comments)](handling-comments.md)
 
 參見 [如何進行程式碼審查](../reviewer/index.md)，該篇文章提供了審查者的詳細指導。

--- a/review/developer/small-cls.md
+++ b/review/developer/small-cls.md
@@ -4,10 +4,10 @@
 
 小而簡單的變更清單是：
 
-- **更快地進行審查。** 審查人員比將 30 分鐘專門用於審查一個大的 CL，更容易找到數次 5 分鐘來審查小的 CL。
-- **更仔細地進行審查。** 對於大的變更，審查人員和作者往往會因為大量的詳細評論來回移位而感到沮喪，有時甚至會錯過或忽略重要點。
-- **較不容易引入錯誤。** 由於進行較少的變更，您和審查人員可以更容易地有效推理 CL 的影響並確認是否引入了錯誤。
-- **在被拒絕時減少浪費的工作。** 如果您編寫了一個龐大的 CL，然後您的審查人員說整個方向錯了，那麼您就浪費了很多工作。
+- **更快地進行審查。** 審查者比將 30 分鐘專門用於審查一個大的 CL，更容易找到數次 5 分鐘來審查小的 CL。
+- **更仔細地進行審查。** 對於大的變更，審查者和作者往往會因為大量的詳細評論來回移位而感到沮喪，有時甚至會錯過或忽略重要點。
+- **較不容易引入錯誤。** 由於進行較少的變更，您和審查者可以更容易地有效推理 CL 的影響並確認是否引入了錯誤。
+- **在被拒絕時減少浪費的工作。** 如果您編寫了一個龐大的 CL，然後您的審查者說整個方向錯了，那麼您就浪費了很多工作。
 - **更容易合併。** 在大的 CL 上工作需要很長時間，因此當您進行合併操作時會遇到很多衝突，而且您還需要經常進行合併。
 - **更方便設計。** 改進小的變更的設計和程式碼更容易，而詳細修改大變更的所有細節要更困難。
 - **在審查時的阻礙更少。** 傳送自包含的整個變更的部分可以讓您在等待當前 CL 審查時繼續編碼。
@@ -24,7 +24,7 @@ Small, simple CLs are:
 - **Less blocking on reviews.** Sending self-contained portions of your overall change allows you to continue coding while you wait for your current CL in review.
 - **Simpler to roll back.** A large CL will more likely touch files that get updated between the initial CL submission and a rollback CL, complicating the rollback (the intermediate CLs will probably need to be rolled back too).
 
-請注意，**評審有權因變更過於龐大而直接拒絕您的變更。**通常他們會感謝您的貢獻，但要求您將其拆成一系列較小的變更。在您已經編寫變更之後，將其拆分可能需要很多工作，或需要花費很多時間爭論評審員為什麼要接受您的大型變更。在最初就編寫小的變更會更容易。
+請注意，**審查者有權因變更過於龐大而直接拒絕您的變更。**通常他們會感謝您的貢獻，但要求您將其拆成一系列較小的變更。在您已經編寫變更之後，將其拆分可能需要很多工作，或需要花費很多時間爭論審查者為什麼要接受您的大型變更。在最初就編寫小的變更會更容易。
 
 Note that **reviewers have discretion to reject your change outright for the sole reason of it being too large.** Usually they will thank you for your contribution but request that you somehow make it into a series of smaller changes. It can be a lot of work to split up a change after you've already written it, or require lots of time arguing about why the reviewer should accept your large change. It's easier to just write small CLs in the first place.
 
@@ -32,11 +32,11 @@ Note that **reviewers have discretion to reject your change outright for the sol
 
 通常而言，對於 CL (程式碼變更清單) 來說，**適當的大小為一項自包含的改變**。這代表：
 
-- CL 的變更應該只針對一件事情，這通常只是一個功能的一部分，而不是整個功能。通常，相較於太大的 CL，寫較小的 CL 會更好一些。與您的審查人員合作找出可以接受的大小。
+- CL 的變更應該只針對一件事情，這通常只是一個功能的一部分，而不是整個功能。通常，相較於太大的 CL，寫較小的 CL 會更好一些。與您的審查者合作找出可以接受的大小。
 - CL 應[包含相關的測試程式碼](#test_code)。
-- 審查人員需要瞭解 CL 的一切(除了未來的開發)是在 CL 本身、CL 的描述、現有的程式碼函式庫或他們已經檢查過的 CL 中。
+- 審查者需要瞭解 CL 的一切(除了未來的開發)是在 CL 本身、CL 的描述、現有的程式碼函式庫或他們已經檢查過的 CL 中。
 - 在 CL 審查後系統將繼續為使用者和開發人員提供良好的功能。
-- CL 的規模不應該太小，其影響難以理解。如果您新增了一個 API，應在同一個 CL 中包含 API 的用法，以便審查人員更好地理解 API 的使用方式。這也可以避免未使用的 API 納入檢查。
+- CL 的規模不應該太小，其影響難以理解。如果您新增了一個 API，應在同一個 CL 中包含 API 的用法，以便審查者更好地理解 API 的使用方式。這也可以避免未使用的 API 納入檢查。
 
 In general, the right size for a CL is **one self-contained change**. This means that:
 
@@ -64,7 +64,7 @@ it's up to the judgment of your reviewer. The number of files that a change is
 spread across also affects its "size." A 200-line change in one file might be
 okay, but spread across 50 files it would usually be too large.
 
-請記得，雖然你從寫程式碼最開始就參與其中，但審查人員常常沒有上下文。對你而言，看起來尺寸合適的程式碼審查可能對審查者來說是難以負荷的。當你不確定時，給審查人員的 CL 應比你認為需要寫的還要小。很少有審查人員會抱怨 CL 太小。
+請記得，雖然你從寫程式碼最開始就參與其中，但審查者常常沒有上下文。對你而言，看起來尺寸合適的程式碼審查可能對審查者來說是難以負荷的。當你不確定時，給審查者的 CL 應比你認為需要寫的還要小。很少有審查者會抱怨 CL 太小。
 
 Keep in mind that although you have been intimately involved with your code from
 the moment you started to write it, the reviewer often has no context. What
@@ -76,8 +76,8 @@ Reviewers rarely complain about getting CLs that are too small.
 
 有一些情況下，大幅度的變更沒有那麼糟糕：
 
-- 通常情況下，刪除整個檔案被視為一行變更，因為審查人員並不需要花太長時間進行審查。
-- 有時候大型 CL 是由完全信任的自動重構工具產生的，審查人員的工作只是驗證並確定他們確實想要進行變更。這樣的 CL 可能會更大，儘管上面提到的一些注意事項（例如合併和測試）仍然適用。
+- 通常情況下，刪除整個檔案被視為一行變更，因為審查者並不需要花太長時間進行審查。
+- 有時候大型 CL 是由完全信任的自動重構工具產生的，審查者的工作只是驗證並確定他們確實想要進行變更。這樣的 CL 可能會更大，儘管上面提到的一些注意事項（例如合併和測試）仍然適用。
 
 There are a few situations in which large changes aren't as bad:
 
@@ -90,7 +90,7 @@ There are a few situations in which large changes aren't as bad:
 
 ## 高效撰寫小型 CL (Writing Small CLs Efficiently) {#efficiently}
 
-如果您撰寫了一個小 CL，然後等待您的審查人員批准它，然後再撰寫下一個 CL，那麼您將浪費很多時間。因此，您希望找到某種不會在等待審查時阻礙您工作的方式。這可能包括同時進行多個項目的工作、找到同意立即提供幫助的審查人員、進行面對面的審查、進行配對程式設計或按照某種方式分割您的 CL，以使您可以立即繼續工作。
+如果您撰寫了一個小 CL，然後等待您的審查者批准它，然後再撰寫下一個 CL，那麼您將浪費很多時間。因此，您希望找到某種不會在等待審查時阻礙您工作的方式。這可能包括同時進行多個項目的工作、找到同意立即提供幫助的審查者、進行面對面的審查、進行配對程式設計或按照某種方式分割您的 CL，以使您可以立即繼續工作。
 
 If you write a small CL and then you wait for your reviewer to approve it before
 you write your next CL, then you're going to waste a lot of time. So you want to
@@ -128,7 +128,7 @@ the first CL. Most version control systems allow you to do this somehow.
 
 ### 依檔案拆分 (Splitting by Files) {#splitting-files}
 
-將 CL (變更清單) 拆分的另一種方法是將檔案分組成需要不同審查人員但本身是獨立變更的內容。
+將 CL (變更清單) 拆分的另一種方法是將檔案分組成需要不同審查者但本身是獨立變更的內容。
 
 Another way to split up a CL is by groupings of files that will require
 different reviewers but are otherwise self-contained changes.
@@ -207,14 +207,14 @@ Starting from the model (at the bottom) and working up to the client:
 
 ## 區分重構 (Separate Out Refactorings) {#refactoring}
 
-通常最好將重構與功能變更或錯誤修復分成不同的確認清單(CL)。例如，移動和重新命名類別應該在不同的 CL 中，不同於修復該類別中的錯誤。當它們是分開的時候，對於審閱者來說更容易理解每個 CL 引入的變更。
+通常最好將重構與功能變更或錯誤修復分成不同的確認清單(CL)。例如，移動和重新命名類別應該在不同的 CL 中，不同於修復該類別中的錯誤。當它們是分開的時候，對於審查者來說更容易理解每個 CL 引入的變更。
 
 It's usually best to do refactorings in a separate CL from feature changes or
 bug fixes. For example, moving and renaming a class should be in a different CL
 from fixing a bug in that class. It is much easier for reviewers to understand
 the changes introduced by each CL when they are separate.
 
-小的清理工作，例如修正本地變數的名稱，可以包含在功能變更或錯誤修正程式碼變更列表中。然而，如果重構的範圍太大，會導致目前程式碼變更列表的審查變得更加困難，那麼這就取決於開發人員和審查人員的判斷了。
+小的清理工作，例如修正本地變數的名稱，可以包含在功能變更或錯誤修正程式碼變更列表中。然而，如果重構的範圍太大，會導致目前程式碼變更列表的審查變得更加困難，那麼這就取決於開發人員和審查者的判斷了。
 
 Small cleanups such as fixing a local variable name can be included inside of a
 feature change or bug fix CL, though. It's up to the judgment of developers and
@@ -282,7 +282,7 @@ CL could pave the way for a cleaner implementation. Talk to your teammates and
 see if anybody has thoughts on how to implement the functionality in small CLs
 instead.
 
-如果所有這些選項失敗（這應該是非常罕見的情況），請事先獲得審閱人的同意來審閱大型 CL，因此他們將會被警告即將到來的事情。在這種情況下，預計要花很長時間進行審查，要特別注意不引入錯誤並勤於編寫測試。
+如果所有這些選項失敗（這應該是非常罕見的情況），請事先獲得審查者的同意來審閱大型 CL，因此他們將會被警告即將到來的事情。在這種情況下，預計要花很長時間進行審查，要特別注意不引入錯誤並勤於編寫測試。
 
 If all of these options fail (which should be extremely rare) then get consent
 from your reviewers in advance to review a large CL, so they are warned about
@@ -290,4 +290,4 @@ what is coming. In this situation, expect to be going through the review process
 for a long time, be vigilant about not introducing bugs, and be extra diligent
 about writing tests.
 
-接下來: [如何處理評審意見 (How to Handle Reviewer Comments)](handling-comments.md)
+接下來: [如何處理審查者意見 (How to Handle Reviewer Comments)](handling-comments.md)

--- a/review/emergencies.md
+++ b/review/emergencies.md
@@ -14,7 +14,7 @@ An emergency CL would be a **small** change that: allows a major launch to
 continue instead of rolling back, fixes a bug significantly affecting users in
 production, handles a pressing legal issue, closes a major security hole, etc.
 
-在緊急情況下，我們真的關心整個程式碼審查過程的速度，而不僅僅是[回覆速度](reviewer/speed.md)。在這種情況下，專家應更關心審查的速度和程式碼的正確性（它是否真正解決了緊急情況？），而不是其他任何事情。此外（很明顯地），當這些問題出現時，此類檢討應優先於所有其他程式碼檢討。
+在緊急情況下，我們真的關心整個程式碼審查過程的速度，而不僅僅是[回覆速度](reviewer/speed.md)。在這種情況下，審查者應更關心審查的速度和程式碼的正確性（它是否真正解決了緊急情況？），而不是其他任何事情。此外（很明顯地），當這些問題出現時，此類檢討應優先於所有其他程式碼檢討。
 
 In emergencies we really do care about the speed of the entire code review
 process, not just the [speed of response](reviewer/speed.md). In this case

--- a/review/index.md
+++ b/review/index.md
@@ -38,13 +38,13 @@ Code reviews should look at:
 
 請檢視 **[如何進行程式碼審查 (How To Do A Code Review)](reviewer/index.md)** 以瞭解更多資訊。
 
-### 選擇最佳評論者 (Picking the Best Reviewers) {#best_reviewers}
+### 選擇最佳審查者 (Picking the Best Reviewers) {#best_reviewers}
 
 一般來說，您會想尋找能夠在合理的時間內回覆您的評論的 *最佳* 審查者。
 
 In general, you want to find the *best* reviewers you can who are capable of responding to your review within a reasonable period of time.
 
-最好的評論者是那些能夠為你撰寫的程式碼提供最全面且正確的評論的人。這通常意味著程式碼的所有者，他們可能是 `OWNERS` 文件中的人，也可能不是。有時這意味著要求不同的人審查 CL 中的不同部分。
+最好的審查者是那些能夠為你撰寫的程式碼提供最全面且正確的評論的人。這通常意味著程式碼的所有者，他們可能是 `OWNERS` 文件中的人，也可能不是。有時這意味著要求不同的人審查 CL 中的不同部分。
 
 The best reviewer is the person who will be able to give you the most thorough and correct review for the piece of code you are writing. This usually means the owner(s) of the code, who may or may not be the people in the OWNERS file. Sometimes this means asking different people to review different parts of the CL.
 
@@ -59,11 +59,11 @@ If you find an ideal reviewer but they are not available, you should at least CC
 
 If you pair-programmed a piece of code with somebody who was qualified to do a good code review on it, then that code is considered reviewed.
 
-您也可以進行面對面的程式碼審查，其中審查人員提問，而變更的開發人員則在被問到時才發言。
+您也可以進行面對面的程式碼審查，其中審查者提問，而變更的開發人員則在被問到時才發言。
 
 You can also do in-person code reviews where the reviewer asks questions and the developer of the change speaks only when spoken to.
 
 ## 參見 (See Also) {#seealso}
 
-- [如何進行程式碼審查 (How To Do A Code Review)](reviewer/index.md)：針對程式碼審查人員的詳細指南。
+- [如何進行程式碼審查 (How To Do A Code Review)](reviewer/index.md)：針對程式碼審查者的詳細指南。
 - [程式碼審查作者指南 (The CL Author's Guide)](developer/index.md)：針對經歷審查的開發人員的詳細指南。

--- a/review/reviewer/comments.md
+++ b/review/reviewer/comments.md
@@ -72,7 +72,7 @@ helpful. The primary goal of code review is to get the best CL possible. A
 secondary goal is improving the skills of developers so that they require less
 and less review over time.
 
-請記住，人們學習的方式不僅是從改進之處，也有從他們做得好的地方進行強化。如果您在程式碼上看到您喜歡的地方，也請提供評論！例如：開發人員整理了混亂的演算法，新增了出色的測試覆蓋率，或者是您作為審閱者從程式碼中學到了東西。與所有評論一樣，請說明您為什麼喜歡某些部分，進一步鼓勵開發人員繼續使用良好的做法。
+請記住，人們學習的方式不僅是從改進之處，也有從他們做得好的地方進行強化。如果您在程式碼上看到您喜歡的地方，也請提供評論！例如：開發人員整理了混亂的演算法，新增了出色的測試覆蓋率，或者是您作為審查者從程式碼中學到了東西。與所有評論一樣，請說明您為什麼喜歡某些部分，進一步鼓勵開發人員繼續使用良好的做法。
 
 Remember that people learn from reinforcement of what they are doing well and
 not just what they could do better. If you see things you like in the CL,

--- a/review/reviewer/looking-for.md
+++ b/review/reviewer/looking-for.md
@@ -32,7 +32,7 @@ thinking about edge cases, looking for concurrency problems, trying to think
 like a user, and making sure that there are no bugs that you see just by reading
 the code.
 
-如果需要的話，您可以驗證變更清單（CL） - 當 CL 產生使用者端影響（例如 UI 變更）時，審閱者檢查 CL 行為是最重要的時候。當您只是閱讀程式碼時，很難理解一些變更會如何影響使用者。對於這樣的更改，如果在 CL 中套用和自行測試太麻煩，您可以要求開發人員向您展示功能的示範。
+如果需要的話，您可以驗證變更清單（CL） - 當 CL 產生使用者端影響（例如 UI 變更）時，審查者檢查 CL 行為是最重要的時候。當您只是閱讀程式碼時，很難理解一些變更會如何影響使用者。對於這樣的更改，如果在 CL 中套用和自行測試太麻煩，您可以要求開發人員向您展示功能的示範。
 
 You *can* validate the CL if you want—the time when it's most important for a
 reviewer to check a CL's behavior is when it has a user-facing impact, such as a
@@ -41,7 +41,7 @@ you're just reading the code. For changes like that, you can have the developer
 give you a demo of the functionality if it's too inconvenient to patch in the CL
 and try it yourself.
 
-另一個需要在程式碼審查中特別考慮功能性的時間是，如果在 CL 中存在某種**並行程式設計**，理論上可能會導致死鎖或競態條件。這些問題通常很難僅透過運行代碼就檢測到，通常需要開發人員和審查人員仔細思考，以確保沒有引入問題。(請注意，這也是不使用可能存在競態條件或死鎖的並發模型的一個很好的理由 - 它可能會使代碼審查或理解程式碼變得非常複雜。)
+另一個需要在程式碼審查中特別考慮功能性的時間是，如果在 CL 中存在某種**並行程式設計**，理論上可能會導致死鎖或競態條件。這些問題通常很難僅透過運行代碼就檢測到，通常需要開發人員和審查者仔細思考，以確保沒有引入問題。(請注意，這也是不使用可能存在競態條件或死鎖的並發模型的一個很好的理由 - 它可能會使代碼審查或理解程式碼變得非常複雜。)
 
 Another time when it's particularly important to think about functionality
 during a code review is if there is some sort of **parallel programming** going
@@ -63,7 +63,7 @@ complex? "Too complex" usually means **"can't be understood quickly by code
 readers."** It can also mean **"developers are likely to introduce bugs when
 they try to call or modify this code."**
 
-一種特定的複雜度是**過度設計**，開發人員使代碼更通用，或新增系統目前不需要的功能。評審者應特別注意過度工程。鼓勵開發人員解決他們現在知道需要解決的問題，而不是開發人員推測*未來*可能需要解決的問題。未來的問題應該在它到來並且您可以在物理宇宙中看到其實際形狀和要求時解決。
+一種特定的複雜度是**過度設計**，開發人員使代碼更通用，或新增系統目前不需要的功能。審查者應特別注意過度工程。鼓勵開發人員解決他們現在知道需要解決的問題，而不是開發人員推測*未來*可能需要解決的問題。未來的問題應該在它到來並且您可以在物理宇宙中看到其實際形狀和要求時解決。
 
 A particular type of complexity is **over-engineering**, where developers have
 made the code more generic than it needs to be, or added functionality that
@@ -218,7 +218,7 @@ code, it's very likely that other developers won't either. So you're also
 helping future developers understand this code, when you ask the developer to
 clarify it.
 
-如果你瞭解程式碼，但是你覺得自己不太適合評審某部分，確保讓這個 CL 有合格的評審(參考 : #every-line-exceptions)，尤其是針對隱私、安全性、併發性、可訪問性、國際化等複雜問題。
+如果你瞭解程式碼，但是你覺得自己不太適合審查某部分，確保讓這個 CL 有合格的審查者(參考 : #every-line-exceptions)，尤其是針對隱私、安全性、併發性、可訪問性、國際化等複雜問題。
 
 If you understand the code but you don't feel qualified to do some part of the
 review, [make sure there is a reviewer](#every-line-exceptions) on the CL who is
@@ -227,7 +227,7 @@ concurrency, accessibility, internationalization, etc.
 
 ### 例外情況 (Exceptions) {#every-line-exceptions}
 
-如果你需要檢查每一行，但這對你來說不合理，該怎麼辦呢？例如，在變更清單上有多個審查人員，你可能會被要求：
+如果你需要檢查每一行，但這對你來說不合理，該怎麼辦呢？例如，在變更清單上有多個審查者，你可能會被要求：
 
 * 檢視屬於較大變更的某些檔案。
 * 檢視變更中的某些方面，例如高層次設計、隱私或安全影響等。
@@ -244,7 +244,7 @@ one of multiple reviewers on a CL and may be asked:
 In these cases, note in a comment which parts you reviewed. Prefer giving
 [LGTM with comments](speed.md#lgtm-with-comments).
 
-如果您希望在確認其他評審已經檢查完變更清單的其他部分後給予 LGTM，請在評論中明確註明以設定期望。一旦變更清單達到所需狀態，請[快速回應](speed.md#responses)。
+如果您希望在確認其他審查者已經檢查完變更清單的其他部分後給予 LGTM，請在評論中明確註明以設定期望。一旦變更清單達到所需狀態，請[快速回應](speed.md#responses)。
 
 If you instead wish to grant LGTM after confirming that other reviewers have
 reviewed other parts of the CL, note this explicitly in a comment to set

--- a/review/reviewer/navigate.md
+++ b/review/reviewer/navigate.md
@@ -34,7 +34,7 @@ However, we're actually going in the direction of removing the FooWidget system
 that you're modifying here, and so we don't want to make any new modifications
 to it right now. How about instead you refactor our new BarWidget class?"
 
-請注意，審查人員不僅拒絕了目前的 CL，並提供了一個替代建議，而且他們用了 *有禮貌的* 方式。這種禮貌是重要的，因為我們希望展現即使意見不同，我們也尊重彼此身為開發人員的事實。
+請注意，審查者不僅拒絕了目前的 CL，並提供了一個替代建議，而且他們用了 *有禮貌的* 方式。這種禮貌是重要的，因為我們希望展現即使意見不同，我們也尊重彼此身為開發人員的事實。
 
 Note that not only did the reviewer reject the current CL and provide an
 alternative suggestion, but they did it *courteously*. This kind of courtesy is

--- a/review/reviewer/pushback.md
+++ b/review/reviewer/pushback.md
@@ -16,14 +16,14 @@ they might really have a better insight about certain aspects of it. Does their
 argument make sense? Does it make sense from a code health perspective? If so,
 let them know that they are right and let the issue drop.
 
-然而，開發人員並非一直正確無誤。在這種情況下，審查人員應進一步解釋為什麼他們認為自己的建議是正確的。一個好的解釋應該展現審查人員對開發人員回覆的理解以及為什麼進行變更的額外資訊。
+然而，開發人員並非一直正確無誤。在這種情況下，審查者應進一步解釋為什麼他們認為自己的建議是正確的。一個好的解釋應該展現審查者對開發人員回覆的理解以及為什麼進行變更的額外資訊。
 
 However, developers are not always right. In this case the reviewer should
 further explain why they believe that their suggestion is correct. A good
 explanation demonstrates both an understanding of the developer's reply, and
 additional information about why the change is being requested.
 
-特別是當審查人員相信他們的建議能夠改進程式碼健康度時，如果他們認為由於改變而產生的程式碼品質提高可以證明額外的工作是有價值的，他們應繼續支援這項更改。**改善程式碼健康度往往是透過一小步實現的。**
+特別是當審查者相信他們的建議能夠改進程式碼健康度時，如果他們認為由於改變而產生的程式碼品質提高可以證明額外的工作是有價值的，他們應繼續支援這項更改。**改善程式碼健康度往往是透過一小步實現的。**
 
 In particular, when the reviewer believes their suggestion will improve code
 health, they should continue to advocate for the change, if they believe the
@@ -38,7 +38,7 @@ the developer know that you *hear* what they're saying, you just don't *agree*.
 
 ## 惹惱開發人員 (Upsetting Developers) {#upsetting_developers}
 
-有些審查人員認為，如果審查者堅持改進，開發人員會感到不悅。有時開發人員確實會感到不悅，但這種情況通常很短暫，之後他們會非常感謝你幫助他們提高程式碼品質。通常，如果您在評論中很[有禮貌](comments.md#courtesy)，開發人員實際上根本不會感到不悅，這種擔憂只存在於審查人員的腦海中。擾動通常更多地與評論的[撰寫方式](comments.md#courtesy)有關，而不是與審查者對代碼品質的堅持。
+有些審查者認為，如果審查者堅持改進，開發人員會感到不悅。有時開發人員確實會感到不悅，但這種情況通常很短暫，之後他們會非常感謝你幫助他們提高程式碼品質。通常，如果您在評論中很[有禮貌](comments.md#courtesy)，開發人員實際上根本不會感到不悅，這種擔憂只存在於審查者的腦海中。擾動通常更多地與評論的[撰寫方式](comments.md#courtesy)有關，而不是與審查者對代碼品質的堅持。
 
 Reviewers sometimes believe that the developer will be upset if the reviewer
 insists on an improvement. Sometimes developers do become upset, but it is

--- a/review/reviewer/speed.md
+++ b/review/reviewer/speed.md
@@ -96,7 +96,7 @@ suggest other reviewers who might be able to respond more quickly, or
 you should interrupt coding even to send a response like this&mdash;send the
 response at a reasonable break point in your work.)
 
-重要的是，評審花足夠的時間進行評審，以確保他們的 "LGTM" 意味著 "這個程式碼符合[我們的標準](standard.md)"。然而，個別回應仍然理想的應是[快速的](#fast)。
+重要的是，審查者花足夠的時間進行審查，以確保他們的 "LGTM" 意味著 "這個程式碼符合[我們的標準](standard.md)"。然而，個別回應仍然理想的應是[快速的](#fast)。
 
 **It is important that reviewers spend enough time on review that they are
 certain their "LGTM" means "this code meets [our standards](standard.md)."**
@@ -132,7 +132,7 @@ comments on the CL. This is done when either:
 The reviewer should specify which of these options they intend, if it is not
 otherwise clear.
 
-當開發者得到 "LGTM, Approval" 需要等待整整一天時，LGTM 帶有評論的功能尤其值得考慮，特別是當開發者和評審人員位於不同的時區時。
+當開發者得到 "LGTM, Approval" 需要等待整整一天時，LGTM 帶有評論的功能尤其值得考慮，特別是當開發者和審查者位於不同的時區時。
 
 LGTM With Comments is especially worth considering when the developer and
 reviewer are in different time zones and otherwise the developer would be
@@ -150,7 +150,7 @@ each other, instead of one huge CL that has to be reviewed all at once. This is
 usually possible and very helpful to reviewers, even if it takes additional work
 from the developer.
 
-如果一個 CL 不能被分成更小的 CL，而且你沒有時間快速檢閱整個 CL，那麼至少對 CL 的整體設計寫一些註解，並將其送回開發人員進行改進。作為審查人員，你的目標之一應該是始終讓開發人員解除障礙或使他們能夠快速進行某些進一步的操作，而不犧牲程式碼的健康狀態。
+如果一個 CL 不能被分成更小的 CL，而且你沒有時間快速檢閱整個 CL，那麼至少對 CL 的整體設計寫一些註解，並將其送回開發人員進行改進。作為審查者，你的目標之一應該是始終讓開發人員解除障礙或使他們能夠快速進行某些進一步的操作，而不犧牲程式碼的健康狀態。
 
 If a CL *can't* be broken up into smaller CLs, and you don't have time to review
 the entire thing quickly, then at least write some comments on the overall
@@ -161,7 +161,7 @@ so.
 
 ## 逐漸改善的程式碼審查 (Code Review Improvements Over Time) {#time}
 
-如果你遵循這些準則，並且在程式碼審查方面嚴格要求自己，你會發現整個程式碼審查過程隨著時間的推移越來越快。開發人員會學習有關代碼健康所需的標準，並向您傳送從一開始就很出色的 CL，需要越來越少的審查時間。審查人員學會了快速響應，並使審查過程不增加不必要的延遲。但是，請不要為了加快速度而妥協於[程式碼審查標準](standard.md)或質量的虛幻改善。長遠來看，這實際上並不會使任何事情發生得更快。
+如果你遵循這些準則，並且在程式碼審查方面嚴格要求自己，你會發現整個程式碼審查過程隨著時間的推移越來越快。開發人員會學習有關代碼健康所需的標準，並向您傳送從一開始就很出色的 CL，需要越來越少的審查時間。審查者學會了快速響應，並使審查過程不增加不必要的延遲。但是，請不要為了加快速度而妥協於[程式碼審查標準](standard.md)或質量的虛幻改善。長遠來看，這實際上並不會使任何事情發生得更快。
 
 If you follow these guidelines and you are strict with your code reviews, you
 should find that the entire code review process tends to go faster and faster

--- a/review/reviewer/standard.md
+++ b/review/reviewer/standard.md
@@ -11,7 +11,7 @@ designed to this end.
 
 In order to accomplish this, a series of trade-offs have to be balanced.
 
-首先，開發人員必須能夠在他們的任務上「取得進展」。如果您從未提交代碼庫的改進，則代碼庫永遠不會得到改進。此外，如果審閱者讓「任何」更改都變得非常困難，那麼開發人員將不會有動力在未來進行改進。
+首先，開發人員必須能夠在他們的任務上「取得進展」。如果您從未提交代碼庫的改進，則代碼庫永遠不會得到改進。此外，如果審查者讓「任何」更改都變得非常困難，那麼開發人員將不會有動力在未來進行改進。
 
 First, developers must be able to _make progress_ on their tasks. If you never
 submit an improvement to the codebase, then the codebase never improves. Also,
@@ -49,7 +49,7 @@ being worked on, even if the CL isn't perfect.**
 
 That is _the_ senior principle among all of the code review guidelines.
 
-當然，這也有限制。例如，如果一個 CL 增加了一個特性，而審查人員不想要這個特性，即使程式碼設計很好，審查人員仍可以否決批准。
+當然，這也有限制。例如，如果一個 CL 增加了一個特性，而審查者不想要這個特性，即使程式碼設計很好，審查者仍可以否決批准。
 
 There are limitations to this, of course. For example, if a CL adds a feature
 that the reviewer doesn't want in their system, then the reviewer can certainly
@@ -66,7 +66,7 @@ _continuous improvement_. A CL that, as a whole, improves the maintainability,
 readability, and understandability of the system shouldn't be delayed for days
 or weeks because it isn't "perfect."
 
-審查人員應該始終可以隨意留下評論，表達某些方面可以更好，但如果這不是非常重要的話，可以在前面加上 "Nit:" 之類的字眼，讓作者知道這只是值得注意的細節，可以選擇忽略。
+審查者應該始終可以隨意留下評論，表達某些方面可以更好，但如果這不是非常重要的話，可以在前面加上 "Nit:" 之類的字眼，讓作者知道這只是值得注意的細節，可以選擇忽略。
 
 Reviewers should _always_ feel free to leave comments expressing that something
 could be better, but if it's not very important, prefix it with something like
@@ -133,7 +133,7 @@ this document and the other documents in
 [The CL Author's Guide](../developer/index.md) and this
 [Reviewer Guide](index.md).
 
-當達成共識變得特別困難時，與其僅透過程式碼審查意見試圖解決衝突，與評審者和作者進行面對面會議或視訊會議可能有所幫助。（如果您這麼做了，請務必記錄討論結果，作為未來讀者的意見。）
+當達成共識變得特別困難時，與其僅透過程式碼審查意見試圖解決衝突，與審查者和作者進行面對面會議或視訊會議可能有所幫助。（如果您這麼做了，請務必記錄討論結果，作為未來讀者的意見。）
 
 When coming to consensus becomes especially difficult, it can help to have a
 face-to-face meeting or a video conference between the reviewer and the author, instead of


### PR DESCRIPTION
您好，目前文件中關於「reviewer」的英文翻譯有部分用詞沒有統一。此文件中的 reviewer 有諸如以下的翻譯：

- 專家
- 評論
- 評審
- 評審者
- 評審人員
- 審查人員
- 查閱人
- 審查人
- 審稿人

為了提高文件中關於 reviewer 用詞的可讀性和一致性，本人這邊發了一個「統一將 reviewer 文字用詞改為『審查者』」的 PR，以避免台灣地區的讀者因為 reviewer 用詞翻譯的不一致而感到困擾。

如果您對此 PR 有任何建議的話，歡迎您隨時通知本人。

感謝您的審查和協助。